### PR TITLE
Exposing port 8089

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,4 +21,5 @@ ARG TENANT_ID
 
 COPY --from=base /code/no-factor-auth.linux no-factor-auth
 
+EXPOSE 8089
 CMD ["./no-factor-auth"]


### PR DESCRIPTION
This is needed in order to work with test containers
(https://www.testcontainers.org/). There might be other work arounds
but not that I could find.