### PR TITLE
Add some v2.0 support to controllers/token

### DIFF
--- a/controllers/token.go
+++ b/controllers/token.go
@@ -86,3 +86,15 @@ func ParseExtraClaims(addClaims []byte)(map[string]interface{}, error){
 
 	return res, err
 }
+
+func TokenV2(claims map[string]interface{}) func(c echo.Context) error {
+	return func(c echo.Context) error {
+
+		a, err := newTokenV2(claims)
+		if err != nil {
+			return err
+		}
+
+		return c.JSON(http.StatusOK, TokenOKResponse{AccessToken: a})
+	}
+}

--- a/controllers/token_test.go
+++ b/controllers/token_test.go
@@ -2,11 +2,25 @@ package controllers
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"reflect"
 	"sort"
 	"testing"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/labstack/echo/v4"
 )
+
+func TestTokenV2(t *testing.T){
+	e := echo.New()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	var tokenClaims map[string]interface{}
+	err := TokenV2(tokenClaims)(c)
+	assert.NoError(t, err)
+}
 
 func TestShouldReturnParseError(t *testing.T) {
 	jsonString := []byte ("malformed json")

--- a/main.go
+++ b/main.go
@@ -34,6 +34,14 @@ func setup(e *echo.Echo) {
 	com.GET("/oauth2/token", controllers.Token)
 }
 
+func setupV2(e *echo.Echo, tokenClaims map[string]interface{}){
+	com := e.Group("/common")
+	com.GET("/v2.0/.well-known/openid-configuration", controllers.OpenIDConfigV2)
+	com.GET("/discovery/v2.0/keys", controllers.Jwks)
+	com.GET("/oauth2/v2.0/authorize", controllers.AuthorizeV2)
+	com.POST("/oauth2/v2.0/token", controllers.TokenV2(tokenClaims))
+}
+
 func version() {
 	fmt.Println("Version:", Version)
 	fmt.Println("Go Version:", runtime.Version())
@@ -61,6 +69,7 @@ func main() {
 	e.Use(middleware.Recover())
 
 	setup(e)
+	setupV2(e, make(map[string]interface{}))
 
 	e.Logger.Fatal(e.Start("0.0.0.0:8089"))
 }

--- a/main.go
+++ b/main.go
@@ -68,8 +68,14 @@ func main() {
 	e.Use(middleware.Logger())
 	e.Use(middleware.Recover())
 
+	tokenClaims := map[string]interface{}{
+                "iss": os.Getenv("TOKEN_ENDPOINT_ISSUER"),
+                "sub": os.Getenv("TOKEN_ENDPOINT_SUBJECT"),
+                "aud": os.Getenv("TOKEN_ENDPOINT_AUDIENCE"),
+        }
+
 	setup(e)
-	setupV2(e, make(map[string]interface{}))
+	setupV2(e, tokenClaims)
 
 	e.Logger.Fatal(e.Start("0.0.0.0:8089"))
 }

--- a/oidc/oidc.go
+++ b/oidc/oidc.go
@@ -147,5 +147,6 @@ func OidcV2(url string) *OpenIDConfig {
 	oidc.JwksURI = url + "/discovery/v2.0/keys"
 	oidc.Issuer = url + "/v2.0"
 	oidc.AuthorizationEndpoint = url + "/oauth2/v2.0/authorize"
+	oidc.TokenEndpoint = url + "/oauth2/v2.0/token"
 	return oidc
 }


### PR DESCRIPTION
When the v2.0 compatible oidc struct where made, only some fields
where added. This batch adds the neccessary field TokenEndpoint.